### PR TITLE
updated .c-layout-revo-slider overflow settings

### DIFF
--- a/resources/assets/assets/base/css/components.css
+++ b/resources/assets/assets/base/css/components.css
@@ -4828,7 +4828,7 @@ h1 {
   background: #ffffff; }
 
 .c-layout-revo-slider {
-  overflow-x: hidden; }
+  overflow: hidden; }
   .c-layout-revo-slider:before,
   .c-layout-revo-slider:after {
     content: " ";


### PR DESCRIPTION
This should fix the double scrollbars seen on the homepage slider.